### PR TITLE
[CI] Use Node.JS LTS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,20 +11,14 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version:
-          - 18
-          - 20
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.JS ${{ matrix.node-version }}
+      - name: Set up Node.JS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "lts/*"
 
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@angular/platform-browser": "^20.0.3",
         "@angular/platform-browser-dynamic": "^20.0.3",
         "@angular/router": "^20.0.3",
-        "@material/web": "^2.2.0 ",
+        "@material/web": "^2.3.0 ",
         "dexie": "^3.2.4",
         "rxjs": "~7.8.0",
         "sdp-transform": "^2.14.1",


### PR DESCRIPTION
This PR updates the Node.JS version used in GitHub Actions, so that it targets the current LTS version.

This should help to get the build to work again.